### PR TITLE
Add CSS radial gradient extent-keywords

### DIFF
--- a/CSS3.tmLanguage
+++ b/CSS3.tmLanguage
@@ -668,7 +668,10 @@
 |scale(X|Y|Z|3d)?|
 |skew(X|Y)?|
 |preserve-3d|
+|closest-side|
+|closest-corner|
 |farthest-side|
+|farthest-corner|
 |textfield|
 |antialiased|grayscale|
 |blink|

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ box, flexbox, flex, column, column-reverse, row, row-reverse,
 wrap, wrap-reverse, start, inline-flex, inline-flexbox
 
 transform, translate, rotate, scale, matrix, skew,
-farthest-side, color-stop, preserve-3d, ellipse
+closest-side, closest-corner, farthest-side,
+farthest-corner, color-stop, preserve-3d, ellipse
 ease-in-out, ease-in, ease-out, from, to
 
 content


### PR DESCRIPTION
Adds 3 more radial-gradient extent-keywords (closest-side, closest-corner, farthest-corner)
See here: https://developer.mozilla.org/en-US/docs/Web/CSS/radial-gradient
