### PR TITLE
add 'block' property value highlighting

### DIFF
--- a/CSS3.tmLanguage
+++ b/CSS3.tmLanguage
@@ -839,7 +839,7 @@
 				geometricPrecision|georgian|groove|
 				hand|hebrew|help|hidden|hiragana-iroha|hiragana|horizontal|
 				ideograph-alpha|ideograph-numeric|ideograph-parenthesis|ideograph-space|inactive|inherit|initial|
-				inline-(box|block|flex|flexbox|grid|table|line-height)|inline|
+				inline-(box|block|flex|flexbox|grid|table|line-height)|inline|block|
 				inside|inter-ideograph|inter-word|italic|
 				(exclude|include)-ruby|
 				(consider|disregard)-shifts|

--- a/src/repository/property-values.xml
+++ b/src/repository/property-values.xml
@@ -56,7 +56,7 @@
 				geometricPrecision|georgian|groove|
 				hand|hebrew|help|hidden|hiragana-iroha|hiragana|horizontal|
 				ideograph-alpha|ideograph-numeric|ideograph-parenthesis|ideograph-space|inactive|inherit|initial|
-				inline-(box|block|flex|flexbox|grid|table|line-height)|inline|
+				inline-(box|block|flex|flexbox|grid|table|line-height)|inline|block|
 				inside|inter-ideograph|inter-word|italic|
 				(exclude|include)-ruby|
 				(consider|disregard)-shifts|


### PR DESCRIPTION
It's strange, but `block` isn't highlighted.

``` css
.whatever {
  display: block;
}
```
